### PR TITLE
Composer: Fetch pear_exception from Packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,4 @@
 {
-    "repositories": [
-       {
-            "type": "package",
-            "package": {
-                "name": "pear/Pear_Exception",
-                "version": "dev-master",
-                "dist": {
-                    "url": "https://github.com/pear/PEAR_Exception/archive/master.zip",
-                    "type": "zip"
-                }
-            }
-        }
-    ],
     "authors": [
         {
             "email": "dbs@php.net",


### PR DESCRIPTION
It has been added to Packagist, so no need to specify repo.

https://packagist.org/packages/pear/pear_exception