### PR TITLE
Support injection of extended Record class

### DIFF
--- a/File/MARC.php
+++ b/File/MARC.php
@@ -147,13 +147,14 @@ class File_MARC extends File_MARCBASE
      * ?>
      * </code>
      *
-     * @param string $source Name of the file, or a raw MARC string
-     * @param int    $type   Source of the input, either SOURCE_FILE or SOURCE_STRING
+     * @param string $source        Name of the file, or a raw MARC string
+     * @param int    $type          Source of the input, either SOURCE_FILE or SOURCE_STRING
+     * @param string $record_class  Record class, defaults to File_MARC_Record
      */
-    function __construct($source, $type = self::SOURCE_FILE)
+    function __construct($source, $type = self::SOURCE_FILE, $record_class = null)
     {
 
-        parent::__construct($source, $type);
+        parent::__construct($source, $type, $record_class);
 
         switch ($type) {
 
@@ -255,7 +256,7 @@ class File_MARC extends File_MARCBASE
      */
     private function _decode($text)
     {
-        $marc = new File_MARC_Record($this);
+        $marc = new $this->record_class($this);
 
         // fallback on the actual byte length
         $record_length = strlen($text);

--- a/File/MARCBASE.php
+++ b/File/MARCBASE.php
@@ -38,6 +38,8 @@
  * @example   marc_yaz.php Pretty print a MARC record retrieved through the PECL yaz extension
  */
 
+require_once 'File/MARC/Record.php';
+
 // {{{ class File_MARCBASE
 /**
  * The main File_MARCBASE class provides common methods for File_MARC and
@@ -58,6 +60,13 @@ class File_MARCBASE
      * @var XMLWriter
      */
     protected $xmlwriter;
+
+    /**
+     * Record class
+     *
+     * @var string
+     */
+    protected $record_class;
     // }}}
 
     // {{{ Constructor: function __construct()
@@ -77,14 +86,17 @@ class File_MARCBASE
      * ?>
      * </code>
      *
-     * @param string $source Name of the file, or a raw MARC string
-     * @param int    $type   Source of the input, either SOURCE_FILE or SOURCE_STRING
+     * @param string $source        Name of the file, or a raw MARC string
+     * @param int    $type          Source of the input, either SOURCE_FILE or SOURCE_STRING
+     * @param string $record_class  Record class, defaults to File_MARC_Record
      */
-    function __construct($source, $type)
+    function __construct($source, $type, $record_class)
     {
         $this->xmlwriter = new XMLWriter();
         $this->xmlwriter->openMemory();
         $this->xmlwriter->startDocument('1.0', 'UTF-8');
+
+        $this->record_class = $record_class ?: File_MARC_Record::class;
     }
     // }}}
 

--- a/File/MARCXML.php
+++ b/File/MARCXML.php
@@ -129,14 +129,15 @@ class File_MARCXML extends File_MARCBASE
      * ?>
      * </code>
      *
-     * @param string $source    Name of the file, or a raw MARC string
-     * @param int    $type      Source of the input, either SOURCE_FILE or SOURCE_STRING
-     * @param string $ns        URI or prefix of the namespace
-     * @param bool   $is_prefix TRUE if $ns is a prefix, FALSE if it's a URI; defaults to FALSE
+     * @param string $source        Name of the file, or a raw MARC string
+     * @param int    $type          Source of the input, either SOURCE_FILE or SOURCE_STRING
+     * @param string $ns            URI or prefix of the namespace
+     * @param bool   $is_prefix     TRUE if $ns is a prefix, FALSE if it's a URI; defaults to FALSE
+     * @param string $record_class  Record class, defaults to File_MARC_Record
      */
-    function __construct($source, $type = self::SOURCE_FILE, $ns = "", $is_prefix = false)
+    function __construct($source, $type = self::SOURCE_FILE, $ns = "", $is_prefix = false, $record_class = null)
     {
-        parent::__construct($source, $type);
+        parent::__construct($source, $type, $record_class);
 
         $this->counter = 0;
 
@@ -215,7 +216,7 @@ class File_MARCXML extends File_MARCBASE
      */
     private function _decode($text)
     {
-        $marc = new File_MARC_Record($this);
+        $marc = new $this->record_class($this);
 
         // Store leader
         $marc->setLeader($text->leader);

--- a/tests/marc_022.phpt
+++ b/tests/marc_022.phpt
@@ -1,0 +1,25 @@
+--TEST--
+marc_022: test Record interface
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php
+$dir = dirname(__FILE__);
+require 'File/MARC.php';
+
+class MyRecord extends File_MARC_Record {
+  public function myNewMethod() {
+    return $this->getField('040')->getSubfield('a')->getData();
+  }
+}
+
+$marc_file = new File_MARC($dir . '/' . 'example.mrc', File_MARC::SOURCE_FILE, MyRecord::class);
+
+$rec = $marc_file->next();
+print get_class($rec) . "\n";
+print $rec->myNewMethod() . "\n";
+
+?>
+--EXPECT--
+MyRecord
+NB

--- a/tests/marc_xml_011.phpt
+++ b/tests/marc_xml_011.phpt
@@ -1,0 +1,24 @@
+--TEST--
+marc_xml_010: iterate and pretty print a MARC record
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php
+$dir = dirname(__FILE__);
+require 'File/MARCXML.php';
+
+class MyRecord extends File_MARC_Record {
+  public function myNewMethod() {
+    return $this->getField('040')->getSubfield('a')->getData();
+  }
+}
+
+$marc_file = new File_MARCXML($dir . '/' . 'repeated_subfields.xml', File_MARCXML::SOURCE_FILE, '', false, MyRecord::class);
+
+$rec = $marc_file->next();
+print get_class($rec) . "\n";
+print $rec->myNewMethod() . "\n";
+
+--EXPECT--
+MyRecord
+DLC


### PR DESCRIPTION
The aim is to allow other packages like [php-marc](https://github.com/scriptotek/php-marc) to extend the Record class with methods that are to specific to go into core File_MARC. I'm currently wrapping File_MARC_Record instead of extending it, but that approach kills all IDE code hinting, and the use of magic methods to simulate extension is probably not good for efficiency either.