### PR TITLE
Regular expressions for getSubfield and getSubfields

### DIFF
--- a/File/MARC/Data_Field.php
+++ b/File/MARC/Data_Field.php
@@ -9,7 +9,7 @@
  * that is part of the Emilda Project (http://www.emilda.org). Christoffer
  * Landtman generously agreed to make the "php-marc" code available under the
  * GNU LGPL so it could be used as the basis of this PEAR package.
- * 
+ *
  * PHP version 5
  *
  * LICENSE: This program is free software; you can redistribute it and/or modify
@@ -98,7 +98,7 @@ class File_MARC_Data_Field extends File_MARC_Field
      * @param string $ind1      first indicator
      * @param string $ind2      second indicator
      */
-    function __construct($tag, array $subfields = null, $ind1 = null, $ind2 = null) 
+    function __construct($tag, array $subfields = null, $ind1 = null, $ind2 = null)
     {
         $this->subfields = new File_MARC_List();
 
@@ -330,15 +330,20 @@ class File_MARC_Data_Field extends File_MARC_Field
      *
      * @param string $code subfield code for which the
      * {@link File_MARC_Subfield} is retrieved
+     * @param bool   $pcre if true, then match as a regular expression
      *
      * @return File_MARC_Subfield returns the first subfield that matches
      * $code, or false if no codes match $code
      */
-    function getSubfield($code = null)
+    function getSubfield($code = null, $pcre = null)
     {
         // iterate merrily through the subfields looking for the requested code
         foreach ($this->subfields as $sf) {
-            if ($sf->getCode() == $code) {
+            if (($pcre
+                && preg_match("/$code/", $sf->getCode()))
+                || (!$pcre
+                && $code == $sf->getCode())
+            ) {
                 return $sf;
             }
         }
@@ -356,12 +361,13 @@ class File_MARC_Data_Field extends File_MARC_Field
      *
      * @param string $code subfield code for which the
      * {@link File_MARC_Subfield} is retrieved
+     * @param bool   $pcre if true, then match as a regular expression
      *
      * @return File_MARC_List|array returns a linked list of all subfields
      * if $code is null, an array of {@link File_MARC_Subfield} objects if
      * one or more subfields match, or an empty array if no codes match $code
      */
-    function getSubfields($code = null)
+    function getSubfields($code = null, $pcre = null)
     {
         $results = array();
 
@@ -373,7 +379,11 @@ class File_MARC_Data_Field extends File_MARC_Field
 
         // iterate merrily through the subfields looking for the requested code
         foreach ($this->subfields as $sf) {
-            if ($sf->getCode() == $code) {
+            if (($pcre
+                && preg_match("/$code/", $sf->getCode()))
+                || (!$pcre
+                && $code == $sf->getCode())
+            ) {
                 $results[] = $sf;
             }
         }
@@ -457,16 +467,16 @@ class File_MARC_Data_Field extends File_MARC_Field
         return (string)$this->ind1.$this->ind2.implode("", $subfields).File_MARC::END_OF_FIELD;
     }
     // }}}
-    
+
     // {{{ getContents()
     /**
      * Return fields data content as joined string
      *
-     * Return all the fields data content as a joined string 
+     * Return all the fields data content as a joined string
      *
      * @param  string $joinChar A string used to join the data conntent.
      * Default is an empty string
-     * 
+     *
      * @return string Joined string
      */
     function getContents($joinChar = '')

--- a/tests/marc_field_006.phpt
+++ b/tests/marc_field_006.phpt
@@ -1,0 +1,51 @@
+--TEST--
+marc_field_006: Test methods getSubfield and getSubfields
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php
+$dir = dirname(__FILE__);
+require 'File/MARC.php';
+
+// create some subfields
+$subfields = array();
+$subfields[] = new File_MARC_Subfield('3', 'number');
+$subfields[] = new File_MARC_Subfield('a', 'character');
+$subfields[] = new File_MARC_Subfield('z', 'another character');
+
+// create a field
+$field = new File_MARC_Data_Field('100', $subfields);
+
+// let's see the results
+$results[] = $field->getSubfield( '[a-z]', true );
+$results = array_merge( $results, $field->getSubfields( 'a' ) );
+$results = array_merge( $results, $field->getSubfields( '[a-z]', true ) );
+$results = array_merge( $results, $field->getSubfields( '[0-9]', true ) );
+$results = array_merge( $results, $field->getSubfields( '.', true ) );
+
+foreach ($results AS $sf) {
+    print $sf;
+    print "\n";
+}
+
+// Check for empty fields
+if ($field->getSubfield( 'd|4|n', true ) === false) {
+    print "Nice! False as result for getSubfield.\n";
+}
+
+$subfields_result = $field->getSubfields( 'd|4|n', true );
+if ( is_array( $subfields_result ) && count( $subfields_result ) === 0 ) {
+    print "Nice! Empty array as result for getSubfields.\n";
+}
+?>
+--EXPECT--
+[a]: character
+[a]: character
+[a]: character
+[z]: another character
+[3]: number
+[3]: number
+[a]: character
+[z]: another character
+Nice! False as result for getSubfield.
+Nice! Empty array as result for getSubfields.


### PR DESCRIPTION
Added support for regular expressions in the getSubfield and getSubfields methods of File_MARC_Data_Field. They behave now the same way as File_MARC_Record's getField and getFields methods.

Included also a test for the methods.