### PR TITLE
Fix positions using MARC_List's appendNode method

### DIFF
--- a/File/MARC/List.php
+++ b/File/MARC/List.php
@@ -9,7 +9,7 @@
  * that is part of the Emilda Project (http://www.emilda.org). Christoffer
  * Landtman generously agreed to make the "php-marc" code available under the
  * GNU LGPL so it could be used as the basis of this PEAR package.
- * 
+ *
  * PHP version 5
  *
  * LICENSE: This program is free software; you can redistribute it and/or modify
@@ -43,7 +43,7 @@
  *
  * For the list of {@link File_MARC_Field} objects in a {@link File_MARC_Record}
  * object, the key() method returns the tag name of the field.
- * 
+ *
  * For the list of {@link File_MARC_Subfield} objects in a {@link
  * File_MARC_Data_Field} object, the key() method returns the code of
  * the subfield.
@@ -133,9 +133,18 @@ class File_MARC_List extends SplDoublyLinkedList
             if ($this->offsetExists($exist_pos + 1)) {
                 $this->add($exist_pos + 1, $new_node);
             } else {
-                $this->push($new_node);
+                $this->appendNode($new_node);
+                return true;
             }
             break;
+        }
+
+        // Fix positions
+        $this->rewind();
+        while ($n = $this->current()) {
+            $n->setPosition($pos);
+            $this->next();
+            $pos++;
         }
 
         return true;

--- a/tests/marc_list_001.phpt
+++ b/tests/marc_list_001.phpt
@@ -1,0 +1,82 @@
+--TEST--
+marc_list_001: Check File_MARC_List methods
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php
+$dir = dirname(__FILE__);
+require 'File/MARC.php';
+
+$list = new File_MARC_List();
+
+// Create fields
+$field1 = new File_MARC_Control_Field( '001', '00001' );
+$field2 = new File_MARC_Control_Field( '002', '00002' );
+$field3 = new File_MARC_Control_Field( '003', '00003' );
+$field4 = new File_MARC_Control_Field( '004', '00004' );
+
+// Check appendNode
+$list->appendNode( $field2 );
+$list->appendNode( $field4 );
+foreach ( $list as $el ) {
+    echo $el->getPosition() . ': ' . $el . "\n";
+}
+echo $list->count() . " nodes\n";
+
+// Check prependNode
+echo "---\n";
+$list->prependNode( $field1 );
+foreach ( $list as $el ) {
+    echo $el->getPosition() . ': ' . $el . "\n";
+}
+echo $list->count() . " nodes\n";
+
+// Check insertNode
+echo "---\n";
+$list->insertNode( $field3, $field2 );
+foreach ( $list as $el ) {
+    echo $el->getPosition() . ': ' . $el . "\n";
+}
+echo $list->count() . " nodes\n";
+
+// Check deleteNode
+echo "---\n";
+$list->deleteNode( $field2 );
+foreach ( $list as $el ) {
+    echo $el->getPosition() . ': ' . $el . "\n";
+}
+echo $list->count() . " nodes\n";
+
+// Check key method
+echo "---\n";
+$list->rewind();
+echo 'Key (field): ' . $list->key() . "\n";
+
+$subfield = new File_MARC_Subfield( 'a', 'test' );
+$list->prependNode( $subfield );
+$list->rewind();
+echo 'Key (subfield): ' . $list->key(). "\n";
+?>
+--EXPECT--
+0: 002     00002
+1: 004     00004
+2 nodes
+---
+0: 001     00001
+1: 002     00002
+2: 004     00004
+3 nodes
+---
+0: 001     00001
+1: 002     00002
+2: 003     00003
+3: 004     00004
+4 nodes
+---
+0: 001     00001
+1: 003     00003
+2: 004     00004
+3 nodes
+---
+Key (field): 001
+Key (subfield): a


### PR DESCRIPTION
The insertNode method in the MARC_List class does not re-index the nodes properly.

This leads to awry behavior especially when the method is used multiple times, because it relies on the positions stored in the nodes.

This fix re-indexes all the nodes every time the method is called. This is not exactly beautiful but I did not come up with a nicer way to do it.