### PR TITLE
Fix composer include-path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,9 @@
         ]
     },
     "description": "Supports the MAchine Readable Cataloging (MARC) file format documented at http://loc.gov/marc/",
-    "include-path": [],
+    "include-path": [
+        "./"
+    ],
     "license": "LGPL-2.1",
     "name": "pear/file_marc",
     "support": {


### PR DESCRIPTION
Seems like I made a mistake back in d8fc57977559e93c9901e9accb218a433a37d7c3 :(

I shouldn't have removed `"./"` from `"include-path"`, it needs to be added back again to get Composer autoloading to work.

Hope you can merge this and push 1.4.1. Sorry for the hassle.