### PR TITLE
Fix Return-Types for PHP 8.1 compability

### DIFF
--- a/File/MARC/Control_Field.php
+++ b/File/MARC/Control_Field.php
@@ -123,7 +123,7 @@ class File_MARC_Control_Field extends File_MARC_Field
      *
      * @return bool Returns true if the field is empty, otherwise false
      */
-    function isEmpty()
+    function isEmpty(): bool
     {
         return ($this->data) ? false : true;
     }

--- a/File/MARC/Data_Field.php
+++ b/File/MARC/Data_Field.php
@@ -400,7 +400,7 @@ class File_MARC_Data_Field extends File_MARC_Field
      *
      * @return bool Returns true if the field is empty, otherwise false
      */
-    function isEmpty()
+    function isEmpty(): bool
     {
         // If $this->subfields is null, we must have deleted it
         if (!$this->subfields) {

--- a/File/MARC/Field.php
+++ b/File/MARC/Field.php
@@ -133,7 +133,7 @@ class File_MARC_Field extends File_MARC_List
      *
      * @return bool Returns true if the field is empty, otherwise false
      */
-    function isEmpty()
+    function isEmpty(): bool
     {
         if ($this->getTag()) {
             return false;

--- a/File/MARC/List.php
+++ b/File/MARC/List.php
@@ -91,9 +91,9 @@ class File_MARC_List extends SplDoublyLinkedList
      * This method enables you to use a foreach iterator to retrieve
      * the tag or code as the key for the iterator.
      *
-     * @return string returns the tag or code
+     * @return int returns the tag or code
      */
-    function key()
+    function key(): int
     {
         if ($this->current() instanceof File_MARC_Field) {
             return $this->current()->getTag();


### PR DESCRIPTION
When upgrading one of our environments to PHP 8.1 we ran into some issues with File_MARC. PHP 8.1 issues errors when function declarations are not compatible regarding the return type. This will be enforced in PHP 9.0 and so it might be wise, to add those.

I tried to fix this here, but I guess that one needs to adjust the composer.json to drop the support of (very) old PHP versions that can't handle return types?